### PR TITLE
shell out for login

### DIFF
--- a/src/subaruAPI.ts
+++ b/src/subaruAPI.ts
@@ -43,7 +43,6 @@ export class SubaruAPI {
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --data '${data}' \
 https://www.mysubaru.com/login`;
-    this.log(cmd);
     const headers = await this.run_cmd(cmd);
 
     this.log('headers: ', headers);


### PR DESCRIPTION
for some reason the login call always fails in native js.  using shell to invoke curl and parse the cookies works for now